### PR TITLE
fix: make document collection serializable

### DIFF
--- a/zep/document_collection.go
+++ b/zep/document_collection.go
@@ -15,7 +15,7 @@ const MaxConcurrentBatches = 5
 
 type DocumentCollection struct {
 	DocumentCollectionModel
-	Client Client
+	Client Client `json:"-"`
 }
 
 func NewDocumentCollection(client Client, params DocumentCollectionModel) *DocumentCollection {


### PR DESCRIPTION
The Client field in DocumentCollectionModel was causing json.Marshal to fail. This fix excludes the client when marshaling the model