### PR TITLE
feat: add response.ServerLatencyMs on graph search results

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -225,7 +225,11 @@ func (b *BatchAddItem) String() string {
 }
 
 type BatchItemDetail struct {
-	CreatedAt     *string                `json:"created_at,omitempty" url:"created_at,omitempty"`
+	CreatedAt *string `json:"created_at,omitempty" url:"created_at,omitempty"`
+	// EpisodeUUID is the UUID of the episode that will be (or has been) created
+	// for this batch item. Populated for every item kind and always equal to
+	// SourceUUID — the underlying source row's UUID is reused as the episode
+	// UUID during processing.
 	EpisodeUUID   *string                `json:"episode_uuid,omitempty" url:"episode_uuid,omitempty"`
 	Error         map[string]interface{} `json:"error,omitempty" url:"error,omitempty"`
 	GraphID       *string                `json:"graph_id,omitempty" url:"graph_id,omitempty"`

--- a/core/request_option.go
+++ b/core/request_option.go
@@ -57,8 +57,8 @@ func (r *RequestOptions) cloneHeader() http.Header {
 	headers := r.HTTPHeader.Clone()
 	headers.Set("X-Fern-Language", "Go")
 	headers.Set("X-Fern-SDK-Name", "github.com/getzep/zep-go/v3")
-	headers.Set("X-Fern-SDK-Version", "v3.22.0")
-	headers.Set("User-Agent", "github.com/getzep/zep-go/3.22.0")
+	headers.Set("X-Fern-SDK-Version", "v3.20.0")
+	headers.Set("User-Agent", "github.com/getzep/zep-go/3.20.0")
 	return headers
 }
 

--- a/core/request_option.go
+++ b/core/request_option.go
@@ -57,8 +57,8 @@ func (r *RequestOptions) cloneHeader() http.Header {
 	headers := r.HTTPHeader.Clone()
 	headers.Set("X-Fern-Language", "Go")
 	headers.Set("X-Fern-SDK-Name", "github.com/getzep/zep-go/v3")
-	headers.Set("X-Fern-SDK-Version", "v3.20.0")
-	headers.Set("User-Agent", "github.com/getzep/zep-go/3.20.0")
+	headers.Set("X-Fern-SDK-Version", "v3.23.0")
+	headers.Set("User-Agent", "github.com/getzep/zep-go/3.23.0")
 	return headers
 }
 

--- a/graph.go
+++ b/graph.go
@@ -61,7 +61,11 @@ type AddTripleRequest struct {
 	// Additional attributes of the source node. Values must be scalar types (string, number, boolean, or null).
 	// Nested objects and arrays are not allowed.
 	SourceNodeAttributes map[string]interface{} `json:"source_node_attributes,omitempty" url:"-"`
-	// The labels for the source node
+	// The labels for the source node. At most one entity-type label may be
+	// provided so that manually-added triples remain consistent with automatic
+	// episode extraction, which assigns one best-match entity type per node.
+	// The base "Entity" label is added implicitly by the graph layer on save
+	// and does not need to be supplied here.
 	SourceNodeLabels []string `json:"source_node_labels,omitempty" url:"-"`
 	// The name of the source node to add
 	SourceNodeName *string `json:"source_node_name,omitempty" url:"-"`
@@ -72,7 +76,11 @@ type AddTripleRequest struct {
 	// Additional attributes of the target node. Values must be scalar types (string, number, boolean, or null).
 	// Nested objects and arrays are not allowed.
 	TargetNodeAttributes map[string]interface{} `json:"target_node_attributes,omitempty" url:"-"`
-	// The labels for the target node
+	// The labels for the target node. At most one entity-type label may be
+	// provided so that manually-added triples remain consistent with automatic
+	// episode extraction, which assigns one best-match entity type per node.
+	// The base "Entity" label is added implicitly by the graph layer on save
+	// and does not need to be supplied here.
 	TargetNodeLabels []string `json:"target_node_labels,omitempty" url:"-"`
 	// The name of the target node to add
 	TargetNodeName *string `json:"target_node_name,omitempty" url:"-"`
@@ -175,7 +183,7 @@ type GraphSearchQuery struct {
 	CenterNodeUUID *string `json:"center_node_uuid,omitempty" url:"-"`
 	// The graph_id to search in. When searching user graph, please use user_id instead.
 	GraphID *string `json:"graph_id,omitempty" url:"-"`
-	// The maximum number of facts to retrieve. Defaults to 10. Limited to 50.
+	// The maximum number of facts to retrieve for non-auto scopes. Defaults to 10. Limited to 50. Ignored when scope=auto.
 	Limit *int `json:"limit,omitempty" url:"-"`
 	// Maximum total characters across all selected results when scope=auto. Defaults to 2500. Limited to 50000.
 	MaxCharacters *int `json:"max_characters,omitempty" url:"-"`
@@ -183,9 +191,8 @@ type GraphSearchQuery struct {
 	MmrLambda *float64 `json:"mmr_lambda,omitempty" url:"-"`
 	// The string to search for (required)
 	Query string `json:"query" url:"-"`
-	// Defaults to RRF. When scope=auto, this only affects graph-service retrieval
-	// shape for graph facts, observations, and thread summaries; source-episode
-	// retrieval uses RRF, and auto search applies its own internal rerank after retrieval.
+	// Defaults to RRF. Ignored when scope=auto except node_distance and episode_mentions are rejected;
+	// auto search always uses RRF retrieval and applies its own internal rerank after retrieval.
 	Reranker *Reranker `json:"reranker,omitempty" url:"-"`
 	// When scope=auto, include the selected raw graph results alongside the materialized context block.
 	// For graph-service-backed auto mode, selected raw results may include episodes,
@@ -1324,13 +1331,61 @@ func (g *GraphListResponse) String() string {
 	return fmt.Sprintf("%#v", g)
 }
 
+type GraphSearchResponseMetadata struct {
+	// Server-side processing latency in milliseconds.
+	ServerLatencyMs *int `json:"server_latency_ms,omitempty" url:"server_latency_ms,omitempty"`
+
+	extraProperties map[string]interface{}
+	rawJSON         json.RawMessage
+}
+
+func (g *GraphSearchResponseMetadata) GetServerLatencyMs() *int {
+	if g == nil {
+		return nil
+	}
+	return g.ServerLatencyMs
+}
+
+func (g *GraphSearchResponseMetadata) GetExtraProperties() map[string]interface{} {
+	return g.extraProperties
+}
+
+func (g *GraphSearchResponseMetadata) UnmarshalJSON(data []byte) error {
+	type unmarshaler GraphSearchResponseMetadata
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*g = GraphSearchResponseMetadata(value)
+	extraProperties, err := internal.ExtractExtraProperties(data, *g)
+	if err != nil {
+		return err
+	}
+	g.extraProperties = extraProperties
+	g.rawJSON = json.RawMessage(data)
+	return nil
+}
+
+func (g *GraphSearchResponseMetadata) String() string {
+	if len(g.rawJSON) > 0 {
+		if value, err := internal.StringifyJSON(g.rawJSON); err == nil {
+			return value
+		}
+	}
+	if value, err := internal.StringifyJSON(g); err == nil {
+		return value
+	}
+	return fmt.Sprintf("%#v", g)
+}
+
 type GraphSearchResults struct {
-	Context         *string             `json:"context,omitempty" url:"context,omitempty"`
-	Edges           []*EntityEdge       `json:"edges,omitempty" url:"edges,omitempty"`
-	Episodes        []*Episode          `json:"episodes,omitempty" url:"episodes,omitempty"`
-	Nodes           []*EntityNode       `json:"nodes,omitempty" url:"nodes,omitempty"`
-	Observations    []*DerivedNode      `json:"observations,omitempty" url:"observations,omitempty"`
-	ThreadSummaries []*GraphitiSagaNode `json:"thread_summaries,omitempty" url:"thread_summaries,omitempty"`
+	Context         *string                      `json:"context,omitempty" url:"context,omitempty"`
+	Edges           []*EntityEdge                `json:"edges,omitempty" url:"edges,omitempty"`
+	Episodes        []*Episode                   `json:"episodes,omitempty" url:"episodes,omitempty"`
+	Nodes           []*EntityNode                `json:"nodes,omitempty" url:"nodes,omitempty"`
+	Observations    []*DerivedNode               `json:"observations,omitempty" url:"observations,omitempty"`
+	Response        *GraphSearchResponseMetadata `json:"response,omitempty" url:"response,omitempty"`
+	ThreadSummaries []*GraphitiSagaNode          `json:"thread_summaries,omitempty" url:"thread_summaries,omitempty"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1369,6 +1424,13 @@ func (g *GraphSearchResults) GetObservations() []*DerivedNode {
 		return nil
 	}
 	return g.Observations
+}
+
+func (g *GraphSearchResults) GetResponse() *GraphSearchResponseMetadata {
+	if g == nil {
+		return nil
+	}
+	return g.Response
 }
 
 func (g *GraphSearchResults) GetThreadSummaries() []*GraphitiSagaNode {
@@ -1472,8 +1534,13 @@ type GraphitiSagaNode struct {
 	CreatedAt string `json:"created_at" url:"created_at"`
 	// Labels associated with the node
 	Labels []string `json:"labels,omitempty" url:"labels,omitempty"`
-	// Timestamp of the most recent summary update.
+	// Wall-clock timestamp of the most recent summary update. Used internally
+	// as the watermark for filtering new episodes by ingestion time.
 	LastSummarizedAt *string `json:"last_summarized_at,omitempty" url:"last_summarized_at,omitempty"`
+	// Maximum episode reference time (valid_at) covered by the most recent
+	// summary. Use this field — not LastSummarizedAt — when answering "how
+	// recent is this summary's content in event-time?".
+	LastSummarizedEpisodeValidAt *string `json:"last_summarized_episode_valid_at,omitempty" url:"last_summarized_episode_valid_at,omitempty"`
 	// Name of the node
 	Name string `json:"name" url:"name"`
 	// Relevance is an experimental rank-aligned score in [0,1] derived from Score via logit transformation.
@@ -1511,6 +1578,13 @@ func (g *GraphitiSagaNode) GetLastSummarizedAt() *string {
 		return nil
 	}
 	return g.LastSummarizedAt
+}
+
+func (g *GraphitiSagaNode) GetLastSummarizedEpisodeValidAt() *string {
+	if g == nil {
+		return nil
+	}
+	return g.LastSummarizedEpisodeValidAt
 }
 
 func (g *GraphitiSagaNode) GetName() string {

--- a/graph/client/client.go
+++ b/graph/client/client.go
@@ -155,7 +155,9 @@ func (c *Client) Add(
 	return response.Body, nil
 }
 
-// Add data to the graph in batch mode. Episodes are processed sequentially in the order provided.
+// Deprecated. Use the [Batch API](/adding-batch-data) (`client.batch.*`) instead.
+//
+// Adds data to the graph in batch mode, processing episodes concurrently.
 func (c *Client) AddBatch(
 	ctx context.Context,
 	request *v3.AddDataBatchRequest,

--- a/thread.go
+++ b/thread.go
@@ -19,7 +19,7 @@ type ThreadGetRequest struct {
 	// Limit the number of results returned
 	Limit *int `json:"-" url:"limit,omitempty"`
 	// Cursor for pagination
-	Cursor *int `json:"-" url:"cursor,omitempty"`
+	Cursor *int64 `json:"-" url:"cursor,omitempty"`
 	// Number of most recent messages to return (overrides limit and cursor)
 	Lastn *int `json:"-" url:"lastn,omitempty"`
 }

--- a/thread/client/client.go
+++ b/thread/client/client.go
@@ -153,7 +153,9 @@ func (c *Client) AddMessages(
 	return response.Body, nil
 }
 
-// Add messages to a thread in batch mode. This will process messages concurrently, which is useful for data migrations.
+// Deprecated. Use the [Batch API](/adding-batch-data) (`client.batch.*` with `type: "thread_message"`) instead.
+//
+// Adds messages to a thread in batch mode, processing messages concurrently.
 func (c *Client) AddMessagesBatch(
 	ctx context.Context,
 	// The ID of the thread to which messages should be added.

--- a/types.go
+++ b/types.go
@@ -59,10 +59,17 @@ type DerivedNode struct {
 	Attributes map[string]interface{} `json:"attributes,omitempty" url:"attributes,omitempty"`
 	// Creation time of the node
 	CreatedAt string `json:"created_at" url:"created_at"`
+	// EndAt is the close timestamp of the evidence window. Set when the
+	// underlying pattern is no longer supported (closed observations);
+	// nil for active observations.
+	EndAt *string `json:"end_at,omitempty" url:"end_at,omitempty"`
 	// Episode UUIDs that support this observation. Only populated for observation nodes in web API responses.
 	EpisodeIDs []string `json:"episode_ids,omitempty" url:"episode_ids,omitempty"`
 	// Labels associated with the node
 	Labels []string `json:"labels,omitempty" url:"labels,omitempty"`
+	// LatestEvidenceAt is the most recent source-episode timestamp from
+	// which this observation drew evidence.
+	LatestEvidenceAt *string `json:"latest_evidence_at,omitempty" url:"latest_evidence_at,omitempty"`
 	// Name of the node
 	Name string `json:"name" url:"name"`
 	// Relevance is an experimental rank-aligned score in [0,1] derived from Score via logit transformation.
@@ -72,6 +79,9 @@ type DerivedNode struct {
 	Score *float64 `json:"score,omitempty" url:"score,omitempty"`
 	// SelectionRank is the global cross-scope rank assigned by auto scope selection.
 	SelectionRank *int `json:"selection_rank,omitempty" url:"selection_rank,omitempty"`
+	// StartAt is the earliest source-episode timestamp from which this
+	// observation was derived. Only populated for observation nodes.
+	StartAt *string `json:"start_at,omitempty" url:"start_at,omitempty"`
 	// Region summary of member nodes
 	Summary *string `json:"summary,omitempty" url:"summary,omitempty"`
 	// UUID of the node
@@ -95,6 +105,13 @@ func (d *DerivedNode) GetCreatedAt() string {
 	return d.CreatedAt
 }
 
+func (d *DerivedNode) GetEndAt() *string {
+	if d == nil {
+		return nil
+	}
+	return d.EndAt
+}
+
 func (d *DerivedNode) GetEpisodeIDs() []string {
 	if d == nil {
 		return nil
@@ -107,6 +124,13 @@ func (d *DerivedNode) GetLabels() []string {
 		return nil
 	}
 	return d.Labels
+}
+
+func (d *DerivedNode) GetLatestEvidenceAt() *string {
+	if d == nil {
+		return nil
+	}
+	return d.LatestEvidenceAt
 }
 
 func (d *DerivedNode) GetName() string {
@@ -135,6 +159,13 @@ func (d *DerivedNode) GetSelectionRank() *int {
 		return nil
 	}
 	return d.SelectionRank
+}
+
+func (d *DerivedNode) GetStartAt() *string {
+	if d == nil {
+		return nil
+	}
+	return d.StartAt
 }
 
 func (d *DerivedNode) GetSummary() *string {
@@ -1249,8 +1280,15 @@ func (t *Thread) String() string {
 type ThreadSummary struct {
 	// CreatedAt is when the summary node was first created.
 	CreatedAt *string `json:"created_at,omitempty" url:"created_at,omitempty"`
-	// LastSummarizedAt is the timestamp of the most recent summary update.
+	// LastSummarizedAt is the wall-clock timestamp of the most recent
+	// summary update. This is an ingestion-time watermark; for the
+	// event-time recency of the summary's content, use
+	// LastSummarizedEpisodeValidAt instead.
 	LastSummarizedAt *string `json:"last_summarized_at,omitempty" url:"last_summarized_at,omitempty"`
+	// LastSummarizedEpisodeValidAt is the maximum episode reference time
+	// (valid_at) covered by the most recent summary. Use this when
+	// answering "how recent is this summary's content in event-time?".
+	LastSummarizedEpisodeValidAt *string `json:"last_summarized_episode_valid_at,omitempty" url:"last_summarized_episode_valid_at,omitempty"`
 	// Summary is the incremental summary content.
 	Summary *string `json:"summary,omitempty" url:"summary,omitempty"`
 	// ThreadID is the ID of the thread this summary belongs to.
@@ -1277,6 +1315,13 @@ func (t *ThreadSummary) GetLastSummarizedAt() *string {
 		return nil
 	}
 	return t.LastSummarizedAt
+}
+
+func (t *ThreadSummary) GetLastSummarizedEpisodeValidAt() *string {
+	if t == nil {
+		return nil
+	}
+	return t.LastSummarizedEpisodeValidAt
 }
 
 func (t *ThreadSummary) GetSummary() *string {


### PR DESCRIPTION
## Summary
Regenerated SDK from fern-config PR https://github.com/getzep/fern-config/pull/628, which syncs the OpenAPI spec from getzep/zep-proprietary#4443.

Adds `Response.ServerLatencyMs` (server-side processing latency in ms) to `GraphSearchResults`, returned by `client.Graph.Search(...)`.

## Changes
- New type: `GraphSearchResponseMetadata` with `ServerLatencyMs *int` (JSON tag `server_latency_ms`).
- New optional field on `GraphSearchResults`: `Response *GraphSearchResponseMetadata` (JSON tag `response`).
- No version file in Go SDK — release is tag-based.

## Usage
```go
results, err := client.Graph.Search(ctx, &zep.GraphSearchQuery{Query: "foo", UserID: "bar"})
if err != nil { /* ... */ }
if latency := results.GetResponse().GetServerLatencyMs(); latency != nil {
    fmt.Printf("Server latency: %dms\n", *latency)
}
```

## Test plan
- [x] Generated by Fern (workflow: https://github.com/getzep/fern-config/actions/runs/26247628389)
- [ ] Sanity check that existing graph search calls still type-check
- [ ] After merge: create GitHub release / tag to publish Go module