### PR TITLE
Prepare Go SDK release automation

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -11,5 +11,6 @@ graph/client/ontology.go
 entity_types.go
 context_string.go
 context_string_test.go
-LICENSEgo.mod
+LICENSE
+go.mod
 go.sum

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: ci
 
-on: [push]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
   compile:
@@ -10,7 +13,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
 
       - name: Compile
         run: go build ./...
@@ -21,7 +24,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
 
       - name: Test
         run: go test ./...


### PR DESCRIPTION
## Summary

- run SDK validation on pull requests while retaining pushes to `main`
- update Go setup actions to their supported Node runtime
- split the malformed `LICENSEgo.mod` Fern ignore entry into `LICENSE` and `go.mod`

## Motivation

The monorepo SDK release orchestrator must be able to wait for CI on Fern-generated pull requests. The corrected `.fernignore` also prevents Fern from modifying the repository-owned license and module manifest.

## Validation

- `actionlint .github/workflows/ci.yml`
- `git diff --check`

## Impact

No SDK runtime code changes. This prepares the Go repository for orchestrated SDK releases.
