### PR TITLE
Preserve CI pull_request trigger from Fern regeneration

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -3,6 +3,7 @@
 README.md
 
 .gitignore
+.github
 examples/
 graph/client/base_entity.go
 graph/client/base_edge.go

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: ci
 
-on: [push]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
   compile:
@@ -10,7 +13,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
 
       - name: Compile
         run: go build ./...
@@ -21,7 +24,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
 
       - name: Test
         run: go test ./...


### PR DESCRIPTION
## Summary
- Restore `pull_request` (and `push` to `main`) on `.github/workflows/ci.yml` so PR checks run again.
- Add `.github` to `.fernignore` so Fern regeneration cannot overwrite release CI (matching the Python and TypeScript SDKs).
- Bump `actions/setup-go` to v5 while restoring the prior automation-ready CI shape.

## Why
The Fern Go generator emits `on: [push]` only. The v3.25.0 regeneration overwrote the hand-maintained CI trigger, so subsequent releases fail a readiness check that requires `pull_request`.

## Test plan
- [ ] Confirm CI runs on this PR (compile + test).
- [ ] Confirm `.fernignore` contains a `.github` line.
- [ ] After merge, close or refresh any open Fern regen PR that still rewrites `ci.yml` without the ignore (e.g. #95), so a merge cannot reintroduce `on: [push]`.


Made with [Cursor](https://cursor.com)